### PR TITLE
Update NLS-OSTownPlan-Edinburgh1849-1851.json

### DIFF
--- a/sources/europe/uk/NLS-OSTownPlan-Edinburgh1849-1851.json
+++ b/sources/europe/uk/NLS-OSTownPlan-Edinburgh1849-1851.json
@@ -1,5 +1,5 @@
 {
-    "url": "http://geo.nls.uk/maps/towns/edinburgh1849/{zoom}/{x}/{-y}.png",
+    "url": "http://geo.nls.uk/maps/towns/edinburgh1849/{zoom}/{x}/{y}.png",
     "attribution": {
         "url": "http://maps.nls.uk/townplans/edinburgh1056_1.html",
         "text": "National Library of Scotland - Edinburgh 1849-1851",


### PR DESCRIPTION
Tile URL updated as per https://wiki.openstreetmap.org/w/index.php?title=National_Library_of_Scotland&diff=1226496&oldid=1222548
Tested in JOSM to confirm the change is indeed correct.