### PR TITLE
explicitly set a locale when sorting files to prevent large diffs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ALL = imagery.geojson imagery.json imagery.xml
-SOURCES = $(shell find sources -type f -name '*.json' | sort)
+SOURCES = $(shell find sources -type f -name '*.json' | LC_ALL="en_US.UTF-8" sort)
 
 all: $(ALL)
 


### PR DESCRIPTION
Sort order depends on the user's `LC_COLLATE`/`LC_ALL` environment variable. Different sort order results in large git commit diffs in the produced imagery.* files.

Explicitly setting a locale (here: `en_US.UTF-8`) makes the sorted output independent of user environment settings.