### PR TITLE
Update the README to reflect a more general name of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,10 @@
-# OSM Editor Imagery Index
+# OSM Editor Layer Index
 
-The goal of this project is to maintain a canonical representation of the imagery
-overlays available to [OpenStreetMap](http://www.openstreetmap.org/) editors such as
-[iD](https://github.com/systemed/iD), [JOSM](http://josm.openstreetmap.de/), and
-[Potlatch 2](https://github.com/systemed/potlatch2).
+The goal of this project is to maintain a canonical representation of the layers available to [OpenStreetMap](http://www.openstreetmap.org/) editors such as [iD](https://github.com/systemed/iD), [JOSM](http://josm.openstreetmap.de/), and [Potlatch 2](https://github.com/systemed/potlatch2).
 
-This list is purely targeted at OpenStreetMap and does not include 
-layers only useful for other projects such as 
-[Open Historical Map](http://www.openhistoricalmap.org/) if the layers 
-are not also useful for OpenStreetMap. With the way this list is structured 
-it is easy to combine it with additional sources of imagery simply by copying 
-the additional sources into their own directory and running `make`. 
+This list is purely targeted at OpenStreetMap and does not include layers only useful for other projects such as [Open Historical Map](http://www.openhistoricalmap.org/) if the layers are not also useful for OpenStreetMap. With the way this list is structured it is easy to combine it with additional layer sources simply by copying the additional sources into their own directory and running `make`. 
 
-Some sources in this list are usable in OpenStreetMap because permission 
-was specifically given to use them with OpenStreetMap and this 
-permission does not extend to other projects. 
+Some sources in this list are usable in OpenStreetMap because permission was specifically given to use them with OpenStreetMap and this permission does not extend to other projects. 
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for help on how to contribute.
 
@@ -22,7 +12,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for help on how to contribute.
 
 If you are using iD, Potlatch 2 or Vespucci, you are already using this index!
 
-For JOSM you can add `http://osmlab.github.io/editor-imagery-index/imagery.xml` 
-to the preference key `imagery.layers.sites` in advanced preferences. You probably
-want to remove the `https://josm.openstreetmap.de/maps` entry or you'll get the 
-same imagery listed twice.
+For JOSM you can add `http://osmlab.github.io/editor-layer-index/imagery.xml` to the preference key `imagery.layers.sites` in advanced preferences. You probably want to remove the `https://josm.openstreetmap.de/maps` entry or you'll get the same layers listed twice.


### PR DESCRIPTION
The project was never meant to be specific to imagery. I named it as such because that's what the majority of the layers were. Let's use a more general name. This updates the readme to reflect the more general name.